### PR TITLE
Add hardcoded function to insert languoid

### DIFF
--- a/glottolog3/__main__.py
+++ b/glottolog3/__main__.py
@@ -287,6 +287,13 @@ def db_url(args):
 def with_session(args):
     setup_session(args.pkg_dir.parent.joinpath('development.ini').as_posix())
 
+@command()
+def add_languoid(args):
+    with_session(args)
+    with transaction.manager:
+        DBSession.add(models.Languoid(id="test0000",
+                                      name="test1",
+                                      level=models.LanguoidLevel.from_string('dialect')))
 
 def main():  # pragma: no cover
     pkg_dir = Path(glottolog3.__file__).parent

--- a/glottolog3/models.py
+++ b/glottolog3/models.py
@@ -222,7 +222,7 @@ class Languoid(CustomModelMixin, Language):
     father_pk = Column(Integer, ForeignKey('languoid.pk'))
     family_pk = Column(Integer, ForeignKey('languoid.pk'))
 
-    level = Column(LanguoidLevel.db_type())
+    level = Column(LanguoidLevel.db_type(), nullable=False)
     status = Column(LanguoidStatus.db_type())
     bookkeeping = Column(Boolean, default=False)
     newick = Column(Unicode)


### PR DESCRIPTION
It looks like it's actually standard protocol to call `DBSession.add(Model(...` and that the constraint checks (for example, not null) are defined in the `models.py` class. Unfortunately, `Languoid` in glottolog inherits from the CLLD `Language` class and `IdNameDescriptionMixin` (https://github.com/clld/clld/blob/9ec79af8abb0277a25242332b69445b0e49a2bcd/src/clld/db/models/_mixins.py). 

These classes define the `name` and `id` (id is the alphanumeric code, i.e. glottocodes for glottolog) meaning that we can't modify these columns to be `nullable=False` or whatever. I tried overriding the columns but was met with errors saying that those columns don't exist on the `languoid` table. So I'm not really sure what the relationship between all these columns is and how/if we can modify their constraints.

Just putting this all out there.