### PR TITLE
Removed placeholder names for API endpoint

### DIFF
--- a/glottolog3/__init__.py
+++ b/glottolog3/__init__.py
@@ -141,8 +141,8 @@ def main(global_config, **settings):
         views.languages,
         renderer='language/bpsearch_html.mako')
     config.add_route(
-        'glottolog.bp_api_search',
-        'bp/api/search')
+        'glottolog.search',
+        '/search')
     config.add_route(
         'glottolog.add_identifier',
         '/identifiers')

--- a/glottolog3/views.py
+++ b/glottolog3/views.py
@@ -325,12 +325,12 @@ def bpsearch(request):
 
 
 @view_config(
-        route_name='glottolog.bp_api_search',
+        route_name='glottolog.search',
         request_method='GET',
         renderer='json')
 def bp_api_search(request):
     query = DBSession.query(Languoid, LanguageIdentifier, Identifier).join(LanguageIdentifier).join(Identifier)
-    term = request.params['bpsearch'].strip().lower()
+    term = request.params['q'].strip().lower()
     namequerytype = request.params.get('namequerytype', 'part').strip().lower()
     multilingual = request.params.get('multilingual', None)
 
@@ -363,8 +363,7 @@ def bp_api_search(request):
         results = query.order_by(Languoid.name)\
                 .options(joinedload(Languoid.family)).all()
         if not results:
-            message = 'No matching languoids found for \'' + term + '\''
-            return [{'message': message}]
+            return []
     
     # group together identifiers that matched for the same languoid
     mapped_results = {k:list(g) for k, g in groupby(results, lambda x: x.Languoid)}

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -116,21 +116,21 @@ def test_feeds(app, feed):
 # BLUEPRINT CODE BEGINS HERE
 @pytest.mark.parametrize('method, path, status, match', [
     # search term requires a minimum of 3 characters
-    ('get', '/bp/api/search?bpsearch=en', None, '[{"message": "Please enter at least three characters for a search."}]'),
+    ('get', '/search?q=en', None, '[{"message": "Please enter at least three characters for a search."}]'),
     # languages can be searched by iso (which counts as an identifier)
-    ('get', '/bp/api/search?bpsearch=lzh', None, '[{"glottocode": "lite1248", "iso": "lzh", "name": "Literary Chinese", "matched_identifiers": ["lzh", "lzh"], "level": "language"}]'),
+    ('get', '/search?q=lzh', None, '[{"glottocode": "lite1248", "iso": "lzh", "name": "Literary Chinese", "matched_identifiers": ["lzh", "lzh"], "level": "language"}]'),
     # languages can be searched by glottocode
-    ('get', '/bp/api/search?bpsearch=kumy1244', None, '[{"glottocode": "kumy1244", "iso": "kum", "name": "Kumyk", "matched_identifiers": [], "level": "language"}]'),
+    ('get', '/search?q=kumy1244', None, '[{"glottocode": "kumy1244", "iso": "kum", "name": "Kumyk", "matched_identifiers": [], "level": "language"}]'),
     # english-only identifier matching by default
-    ('get', '/bp/api/search?bpsearch=anglai', None, '[{"message": "No matching languoids found for \'anglai\'"}]'),
+    ('get', '/search?q=anglai', None, '[]'),
     # multilingual indentifier matching allows more results
-    ('get', '/bp/api/search?bpsearch=anglai&multilingual=true', None, '[{"glottocode": "stan1293", "iso": "eng", "name": "English", "matched_identifiers": ["Anglais moderne", "anglais"], "level": "language"}, {"glottocode": "midd1317", "iso": "enm", "name": "Middle English", "matched_identifiers": ["Moyen anglais", "anglais moyen (1100-1500)"], "level": "language"}, {"glottocode": "tsha1245", "iso": "tsj", "name": "Tshangla", "matched_identifiers": ["Tshanglaish"], "level": "language"}]'),
+    ('get', '/search?q=anglai&multilingual=true', None, '[{"glottocode": "stan1293", "iso": "eng", "name": "English", "matched_identifiers": ["Anglais moderne", "anglais"], "level": "language"}, {"glottocode": "midd1317", "iso": "enm", "name": "Middle English", "matched_identifiers": ["Moyen anglais", "anglais moyen (1100-1500)"], "level": "language"}, {"glottocode": "tsha1245", "iso": "tsj", "name": "Tshangla", "matched_identifiers": ["Tshanglaish"], "level": "language"}]'),
     # partial word matching set by default
-    ('get', '/bp/api/search?bpsearch=klar', None, '[{"glottocode": "kumy1244", "iso": "kum", "name": "Kumyk", "matched_identifiers": ["Kumuklar"], "level": "language"}]'),
+    ('get', '/search?q=klar', None, '[{"glottocode": "kumy1244", "iso": "kum", "name": "Kumyk", "matched_identifiers": ["Kumuklar"], "level": "language"}]'),
     # whole word matching removes partial-match results
-    ('get', '/bp/api/search?bpsearch=klar&namequerytype=whole', None, '[{"message": "No matching languoids found for \'klar\'"}]'),
+    ('get', '/search?q=klar&namequerytype=whole', None, '[]'),
     # whole word match successful
-    ('get', '/bp/api/search?bpsearch=Literary%20Chinese&namequerytype=whole', None, '[{"glottocode": "lite1248", "iso": "lzh", "name": "Literary Chinese", "matched_identifiers": ["Literary Chinese", "Literary Chinese"], "level": "language"}]'),
+    ('get', '/search?q=Literary%20Chinese&namequerytype=whole', None, '[{"glottocode": "lite1248", "iso": "lzh", "name": "Literary Chinese", "matched_identifiers": ["Literary Chinese", "Literary Chinese"], "level": "language"}]'),
 ])
 
 def test_search_api(app, method, path, status, match):


### PR DESCRIPTION
Changed API endpoint to be named /search, and for the search parameter to be called q.
A search yielding no languoids will now return an empty list.