### PR TITLE
Order language search results by identifier matching

### DIFF
--- a/glottolog3/views.py
+++ b/glottolog3/views.py
@@ -323,17 +323,20 @@ def bpsearch(request):
     return {'message': message, 'params': params, 'languoids': languoids,
             'map': map_, 'countries': countries}
 
-def identifier_similarity(identifiers, term):
+def identifier_score(identifier, term):
     # sorting key method that will return a lower rank for greater similarity
+    if identifier == term:
+        return 0
+    elif identifier.startswith(term):
+        return 1
+    elif ' ' + term in identifier:
+        return 2
+    return 3
+
+def best_identifier_score(identifiers, term):
     rank = 3
     for i in identifiers:
-        if i.Identifier.name == term:
-            rank = 0
-        elif i.Identifier.name.startswith(term):
-            rank = min(rank, 1)
-        elif ' ' + term in i.Identifier.name:
-            rank = min(rank, 2)
-
+        rank = min(rank,identifier_score(i.Identifier.name,term))
     return rank
 
 @view_config(
@@ -380,14 +383,14 @@ def bp_api_search(request):
     # group together identifiers that matched for the same languoid
     mapped_results = {k:list(g) for k, g in groupby(results, lambda x: x.Languoid)}
     # order languoid results by greatest identifier similarity, and then by name to break ties + consistency
-    ordered_results = OrderedDict(sorted(mapped_results.items(), key=lambda (k, v): (identifier_similarity(v,term), k.name)))
+    ordered_results = OrderedDict(sorted(mapped_results.items(), key=lambda (k, v): (best_identifier_score(v,term), k.name)))
 
     return [{
         'name': k.name,
         'glottocode': k.id,
         'iso': k.hid if k.hid else '',
         'level': k.level.name,
-        'matched_identifiers': [i.Identifier.name for i in v] if kind != 'Glottocode' else [],
+        'matched_identifiers': sorted(set([i.Identifier.name for i in v]), key=lambda x: identifier_score(x, term))  if kind != 'Glottocode' else [],
         } for k, v in ordered_results.items()]
 
 

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -123,7 +123,7 @@ def test_feeds(app, feed):
     ('get', '/search?q=kumy1244', None, '[{"glottocode": "kumy1244", "iso": "kum", "name": "Kumyk", "matched_identifiers": [], "level": "language"}]'),
     # english-only identifier matching by default
     ('get', '/search?q=anglai', None, '[]'),
-    # multilingual indentifier matching allows more results
+    # multilingual indentifier matching allows more results. The results are ordered by identifier similarity
     ('get', '/search?q=anglai&multilingual=true', None, '[{"glottocode": "stan1293", "iso": "eng", "name": "English", "matched_identifiers": ["Anglais moderne", "anglais"], "level": "language"}, {"glottocode": "midd1317", "iso": "enm", "name": "Middle English", "matched_identifiers": ["Moyen anglais", "anglais moyen (1100-1500)"], "level": "language"}, {"glottocode": "tsha1245", "iso": "tsj", "name": "Tshangla", "matched_identifiers": ["Tshanglaish"], "level": "language"}]'),
     # partial word matching set by default
     ('get', '/search?q=klar', None, '[{"glottocode": "kumy1244", "iso": "kum", "name": "Kumyk", "matched_identifiers": ["Kumuklar"], "level": "language"}]'),

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -118,19 +118,19 @@ def test_feeds(app, feed):
     # search term requires a minimum of 3 characters
     ('get', '/search?q=en', None, '[{"message": "Please enter at least three characters for a search."}]'),
     # languages can be searched by iso (which counts as an identifier)
-    ('get', '/search?q=lzh', None, '[{"glottocode": "lite1248", "iso": "lzh", "name": "Literary Chinese", "matched_identifiers": ["lzh", "lzh"], "level": "language"}]'),
+    ('get', '/search?q=lzh', None, '[{"glottocode": "lite1248", "iso": "lzh", "name": "Literary Chinese", "matched_identifiers": ["lzh"], "level": "language"}]'),
     # languages can be searched by glottocode
     ('get', '/search?q=kumy1244', None, '[{"glottocode": "kumy1244", "iso": "kum", "name": "Kumyk", "matched_identifiers": [], "level": "language"}]'),
     # english-only identifier matching by default
     ('get', '/search?q=anglai', None, '[]'),
     # multilingual indentifier matching allows more results. The results are ordered by identifier similarity
-    ('get', '/search?q=anglai&multilingual=true', None, '[{"glottocode": "stan1293", "iso": "eng", "name": "English", "matched_identifiers": ["Anglais moderne", "anglais"], "level": "language"}, {"glottocode": "midd1317", "iso": "enm", "name": "Middle English", "matched_identifiers": ["Moyen anglais", "anglais moyen (1100-1500)"], "level": "language"}, {"glottocode": "tsha1245", "iso": "tsj", "name": "Tshangla", "matched_identifiers": ["Tshanglaish"], "level": "language"}]'),
+    ('get', '/search?q=anglai&multilingual=true', None, '[{"glottocode": "stan1293", "iso": "eng", "name": "English", "matched_identifiers": ["anglais", "Anglais moderne"], "level": "language"}, {"glottocode": "midd1317", "iso": "enm", "name": "Middle English", "matched_identifiers": ["anglais moyen (1100-1500)", "Moyen anglais"], "level": "language"}, {"glottocode": "tsha1245", "iso": "tsj", "name": "Tshangla", "matched_identifiers": ["Tshanglaish"], "level": "language"}]'),
     # partial word matching set by default
     ('get', '/search?q=klar', None, '[{"glottocode": "kumy1244", "iso": "kum", "name": "Kumyk", "matched_identifiers": ["Kumuklar"], "level": "language"}]'),
     # whole word matching removes partial-match results
     ('get', '/search?q=klar&namequerytype=whole', None, '[]'),
     # whole word match successful
-    ('get', '/search?q=Literary%20Chinese&namequerytype=whole', None, '[{"glottocode": "lite1248", "iso": "lzh", "name": "Literary Chinese", "matched_identifiers": ["Literary Chinese", "Literary Chinese"], "level": "language"}]'),
+    ('get', '/search?q=Literary%20Chinese&namequerytype=whole', None, '[{"glottocode": "lite1248", "iso": "lzh", "name": "Literary Chinese", "matched_identifiers": ["Literary Chinese"], "level": "language"}]'),
 ])
 
 def test_search_api(app, method, path, status, match):


### PR DESCRIPTION
Language results are now returned in order based on how relevant their most relevant identifier is to the search term.
Currently the ordering goes:
Full match i.e. english = english
First word begins with search term i.e. 'english language'.startswith('english')
Non-first word begins with search term i.e. 'middle english'.contains(' english')
All other results.

Ties are broken by alphabetical order of language name.