### PR TITLE
made identical identifier comparison case insensitive + length comparison

### DIFF
--- a/glottolog3/views.py
+++ b/glottolog3/views.py
@@ -325,13 +325,15 @@ def bpsearch(request):
 
 def identifier_score(identifier, term):
     # sorting key method that will return a lower rank for greater similarity
-    if identifier == term:
+    lower_id = identifier.lower()
+    coverage = float(len(term))/len(lower_id)
+    if lower_id == term:
         return 0
-    elif identifier.startswith(term):
-        return 1
-    elif ' ' + term in identifier:
-        return 2
-    return 3
+    elif lower_id.startswith(term):
+        return 1 - coverage
+    elif ' ' + term in lower_id:
+        return 2 - coverage
+    return 3 - coverage
 
 def best_identifier_score(identifiers, term):
     rank = 3


### PR DESCRIPTION
Improved identifier ranking by making comparison case insensitive and tie-breaking on length comparison (for the search term "anglai", "anglais" will match ahead of "anglais moderne", len(term)/len(identifier))