### PR TITLE
fix tests and search behaviour

### DIFF
--- a/glottolog3/views.py
+++ b/glottolog3/views.py
@@ -49,8 +49,8 @@ def best_identifier_score(identifiers, term):
 def bp_api_search(request):
     query = DBSession.query(Languoid, LanguageIdentifier, Identifier).join(LanguageIdentifier).join(Identifier)
     term = request.params['q'].strip().lower()
-    whole = request.params.get('whole', False)
-    multilingual = request.params.get('multilingual', True)
+    whole = request.params.get('whole', "False")
+    multilingual = request.params.get('multilingual', "True")
 
     MIN_QUERY_LEN = 3
 
@@ -66,11 +66,11 @@ def bp_api_search(request):
         filters = []
         ul_iname = func.unaccent(func.lower(Identifier.name))
         ul_name = func.unaccent(term)
-        if whole:
+        if whole.lower() == 'true':
             filters.append(ul_iname == ul_name)
         else:
             filters.append(ul_iname.contains(ul_name))
-        if not multilingual:
+        if multilingual.lower() == 'false':
             # restrict to English identifiers
             filters.append(func.coalesce(Identifier.lang, '').in_((u'', u'eng', u'en')))
 

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -1,26 +1,38 @@
 import pytest
 
-@pytest.mark.parametrize('method, path, status, match', [
+@pytest.mark.parametrize('path, match', [
     # search term requires a minimum of 3 characters
-    ('get', '/search?q=en', None, '[{"message": "Query must be at least 3 characters."}]'),
+    ('/search?q=en', '[{"message": "Query must be at least 3 characters."}]'),
     # languages can be searched by iso (which counts as an identifier)
-    ('get', '/search?q=lzh', None, '[{"glottocode": "lite1248", "iso": "lzh", "name": "Literary Chinese", "matched_identifiers": ["lzh"], "level": "language"}]'),
+    ('/search?q=lzh', '[{"glottocode": "lite1248", "iso": "lzh", "name": "Literary Chinese", "matched_identifiers": ["lzh"], "level": "language"}]'),
     # languages can be searched by glottocode
-    ('get', '/search?q=kumy1244', None, '[{"glottocode": "kumy1244", "iso": "kum", "name": "Kumyk", "matched_identifiers": [], "level": "language"}]'),
+    ('/search?q=kumy1244', '[{"glottocode": "kumy1244", "iso": "kum", "name": "Kumyk", "matched_identifiers": [], "level": "language"}]'),
     # Multilingual set to false
-    ('get', '/search?q=anglai&multilingual=false', None, '[]'),
+    ('/search?q=anglai&multilingual=false', '[]'),
     # multilingual indentifier matching allows more results. The results are ordered by identifier similarity
-    ('get', '/search?q=anglai&multilingual=true', None, '[{"glottocode": "stan1293", "iso": "eng", "name": "English", "matched_identifiers": ["anglais", "Anglais moderne"], "level": "language"}, {"glottocode": "midd1317", "iso": "enm", "name": "Middle English", "matched_identifiers": ["anglais moyen (1100-1500)", "Moyen anglais"], "level": "language"}, {"glottocode": "tsha1245", "iso": "tsj", "name": "Tshangla", "matched_identifiers": ["Tshanglaish"], "level": "language"}]'),
+    ('/search?q=anglai&multilingual=true', '[{"glottocode": "stan1293", "iso": "eng", "name": "English", "matched_identifiers": ["anglais", "Anglais moderne"], "level": "language"}, {"glottocode": "midd1317", "iso": "enm", "name": "Middle English", "matched_identifiers": ["anglais moyen (1100-1500)", "Moyen anglais"], "level": "language"}, {"glottocode": "tsha1245", "iso": "tsj", "name": "Tshangla", "matched_identifiers": ["Tshanglaish"], "level": "language"}]'),
     # partial word matching set by default
-    ('get', '/search?q=klar', None, '[{"glottocode": "kumy1244", "iso": "kum", "name": "Kumyk", "matched_identifiers": ["Kumuklar"], "level": "language"}]'),
+    ('/search?q=klar', '[{"glottocode": "kumy1244", "iso": "kum", "name": "Kumyk", "matched_identifiers": ["Kumuklar"], "level": "language"}]'),
     # whole word matching removes partial-match results
-    ('get', '/search?q=klar&whole=true', None, '[]'),
+    ('/search?q=klar&whole=true', '[]'),
     # whole word match successful
-    ('get', '/search?q=Literary%20Chinese&whole=true', None, '[{"glottocode": "lite1248", "iso": "lzh", "name": "Literary Chinese", "matched_identifiers": ["Literary Chinese"], "level": "language"}]'),
+    ('/search?q=Literary%20Chinese&whole=true', '[{"glottocode": "lite1248", "iso": "lzh", "name": "Literary Chinese", "matched_identifiers": ["Literary Chinese"], "level": "language"}]'),
 ])
 
-def test_search_api(app, method, path, status, match):
-    kwargs = {'status': status} if status is not None else {'status': 200}
-    res = getattr(app, method)(path, **kwargs)
+def test_search_api(app, path, match):
+    kwargs = {'status': 200}
+    res = app.get(path, **kwargs)
     if match is not None:
         assert match in res
+
+@pytest.mark.parametrize('path, status, match', [
+    # generic English
+    ('/languoid/stan1293', 200, '"id": "stan1293", "name": "English", "level": "Language"'),
+    # glottocode with proper format that doesn't exist
+    ('/languoid/test1111', 404, '"error"'),
+    # glottocode with improper format
+    ('/languoid/test11111', 404, '"error"'),
+])
+def test_languoid_get(app, path, status, match):
+    res = app.get(path, {'status': status}, expect_errors=True)
+    assert match in res


### PR DESCRIPTION
simiplify parameters of search endpoint tests. Used `expect_errors=True` for languoid GET tests. tweaked behaviour of search API to use string representations of boolean parameters